### PR TITLE
Fix URL properties of version files

### DIFF
--- a/Blueshift.version
+++ b/Blueshift.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Blueshift",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Blueshift/master/GameData/WildBlueIndustries/Blueshift/Blueshift.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/Blueshift/master/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version",
     "DOWNLOAD":"https://github.com/Angel-125/Blueshift/releases",
     "GITHUB":
     {

--- a/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Blueshift",
-    "URL":"https://github.com/Angel-125/Blueshift/raw/master/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/Blueshift/master/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version",
     "DOWNLOAD":"https://github.com/Angel-125/Blueshift/releases",
     "GITHUB":
     {

--- a/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Blueshift",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Blueshift/master/GameData/WildBlueIndustries/Blueshift/Blueshift.version",
+    "URL":"https://github.com/Angel-125/Blueshift/raw/master/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Blueshift.version",
     "DOWNLOAD":"https://github.com/Angel-125/Blueshift/releases",
     "GITHUB":
     {


### PR DESCRIPTION
The current URL property isn't a usable URL. I'm guessing it's intended to be the one under ReleaseFolder, so this PR fixes both files to use that.

Caught by the validation scripts on KSP-CKAN/NetKAN#8357.

Tagging @Angel-125 because GitHub's pull request notifications make no sense by default.