### PR TITLE
Fix for some SpaceDust compat issues

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/SpaceDust.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/SpaceDust.cfg
@@ -43,8 +43,8 @@ SPACEDUST_RESOURCE:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 
 	RESOURCEBAND
 	{
-		name = KerbolGraviolium
-		title = Kerbol Graviolium Belt
+		name = JoolGraviolium
+		title = Jool Graviolium Belt
 
 		minAbundance = 0.0000000000000000000012
 		maxAbundance = 0.0000000000000000000025
@@ -80,8 +80,8 @@ SPACEDUST_RESOURCE:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust,JNSQ]
 
 	RESOURCEBAND
 	{
-		name = KerbolGraviolium
-		title = Kerbol Graviolium Belt
+		name = LindorGraviolium
+		title = Lindor Graviolium Belt
 
 		minAbundance = 0.0000000000000000000012
 		maxAbundance = 0.0000000000000000000025
@@ -117,8 +117,8 @@ SPACEDUST_RESOURCE:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust,GEP]
 
 	RESOURCEBAND
 	{
-		name = KerbolGraviolium
-		title = Kerbol Graviolium Belt
+		name = GrannusGraviolium
+		title = Grannus Graviolium Belt
 
 		minAbundance = 0.00000000120
 		maxAbundance = 0.00000000380
@@ -145,4 +145,35 @@ SPACEDUST_RESOURCE:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust,GEP]
 		latVariability = 0
 		latFalloffType = Linear
 	}
+}
+
+
+// affects visibility of Graviolium belts in UI
+@SPACEDUSTSETTINGS:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
+{
+	@ResourceVisibilities
+	{
+		name = Graviolium
+	}
+}
+
+// adds Graviolium scanning to FFT gas scanner
+@PART[fft-scanner-gas-1]:NEEDS[!WildBlueIndustries/FlyingSaucers,FarFutureTechnologies]
+{
+    @MODULE[ModuleSpaceDustScanner]
+    {
+        SCANNED_RESOURCE
+        {
+            name = Graviolium
+            // How to discover resources. Possible values are None, Local, SOI, Altitude
+            DiscoverMode = Altitude
+            // How to discover resources. Possible values are None, Local, SOI, Altitude
+            IdentifyMode = Altitude
+            // Range for Altitude mode
+            DiscoverRange = 5000000
+            // Range for Altitude mode
+            IdentifyRange = 500000
+        }
+    }
+
 }

--- a/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/SpaceDust.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/SpaceDust.cfg
@@ -155,6 +155,11 @@ SPACEDUST_RESOURCE:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust,GEP]
 	{
 		name = Graviolium
 	}
+	
+	@ResourceColors
+	{
+		Graviolium = 0, 0.63, 0.91, 1
+	}
 }
 
 // adds Graviolium scanning to FFT gas scanner

--- a/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Resources/ResourceDefinitions.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Resources/ResourceDefinitions.cfg
@@ -7,7 +7,7 @@ RESOURCE_DEFINITION:NEEDS[!KFS]
 {
 	name = Graviolium
 	displayName = Graviolium
-	density = 0.0
+	density = 0.001
 	unitCost = 250
 	hsp = 10
 	flowMode = ALL_VESSEL


### PR DESCRIPTION
Adds Graviolium SpaceDust UI support, adds ability to detect Graviolium when FFT is installed, and adds mass for Graviolium to fix SpaceDust issue, and renames mislabeled Graviolium belts.