### PR TITLE
Optional patch to increase drive costs

### DIFF
--- a/ReleaseFolder/Extras/ExpensiveDrives.cfg
+++ b/ReleaseFolder/Extras/ExpensiveDrives.cfg
@@ -1,0 +1,10 @@
+// makes Blueshift warp drive components significantly more expensive
+//
+// author: Grimmas
+//
+
+@[wbiMk2FusionReactor,wbiS2FusionReactor,wbiS3FusionReactor,wbiMk2GraviticGenerator,wbiMk2WarpCoil,wbiMk2WarpCore,wbiMk2WarpRing,wbiS1WarpCoil,wbiS2GravimetricGenerator,wbiS2WarpCoil,wbiS2WarpCore,wbiS32WarpRing,wbiS3GravimetricGenerator,wbiS3HeavyWarpSustainer,wbiS3WarpCore,wbiS3WarpEngine,wbiS3WarpSustainer]:NEEDS[Blueshift]
+{
+    @entryCost *= 100
+    @cost *= 100
+}

--- a/ReleaseFolder/Extras/ExpensiveDrives.cfg
+++ b/ReleaseFolder/Extras/ExpensiveDrives.cfg
@@ -3,7 +3,7 @@
 // author: Grimmas
 //
 
-@[wbiMk2FusionReactor,wbiS2FusionReactor,wbiS3FusionReactor,wbiMk2GraviticGenerator,wbiMk2WarpCoil,wbiMk2WarpCore,wbiMk2WarpRing,wbiS1WarpCoil,wbiS2GravimetricGenerator,wbiS2WarpCoil,wbiS2WarpCore,wbiS32WarpRing,wbiS3GravimetricGenerator,wbiS3HeavyWarpSustainer,wbiS3WarpCore,wbiS3WarpEngine,wbiS3WarpSustainer]:NEEDS[Blueshift]
+@PART[wbiMk2FusionReactor,wbiS2FusionReactor,wbiS3FusionReactor,wbiMk2GraviticGenerator,wbiMk2WarpCoil,wbiMk2WarpCore,wbiMk2WarpRing,wbiS1WarpCoil,wbiS2GravimetricGenerator,wbiS2WarpCoil,wbiS2WarpCore,wbiS32WarpRing,wbiS3GravimetricGenerator,wbiS3HeavyWarpSustainer,wbiS3WarpCore,wbiS3WarpEngine,wbiS3WarpSustainer]:NEEDS[Blueshift]
 {
     @entryCost *= 100
     @cost *= 100


### PR DESCRIPTION
This makes unlocking and using the warp drive components and fusion generators cost 100x more. 
Added as an optional "extras" patch because this may not appeal to everyone.