### PR TITLE
Update FFT patch for misspelling of LqdDeuterium

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/FarFutureTechnologies.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/FarFutureTechnologies.cfg
@@ -208,7 +208,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,!WildBlueTools,FarFutureTechnologies]
 
 	RESOURCE
 	{
-		name = LqDeuterium
+		name = LqdDeuterium
 		unitsPerVolume = 0.2
 	}
 }
@@ -220,7 +220,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,!WildBlueTools,FarFutureTechnologies]
 
 	RESOURCE
 	{
-		name = LqDeuterium
+		name = LqdDeuterium
 		unitsPerVolume = 0.1
 	}
 	RESOURCE


### PR DESCRIPTION
Resource LqdDeuterium misspelt as LqDeuterium in FFT patch.

Also there seems to be a mismatch between the patch signatures in that file relating to this. The tank type "bsLqDeuterium" is defined in line 204 with:

B9_TANK_TYPE:NEEDS[B9PartSwitch,!WildBlueTools,FarFutureTechnologies]

but then the two patches that use it on lines 233 and 269 are:

@PART[wbiS2Endcap,wbiMk2PropellantTank]:NEEDS[B9PartSwitch,!WildBlueTools,!FarFutureTechnologies]

@PART[wbiS1Endcap]:NEEDS[B9PartSwitch,!WildBlueTools,!FarFutureTechnologies]

Note the switch from NEEDS[...,FarFutureTechnologies] to !FarFutureTechnologies

I think the !FarFutureTechnologies is the mistake in this case?