### PR TITLE
Fix SpaceDust harvesters

### DIFF
--- a/Patches/SpaceDustForBlueshift.cfg
+++ b/Patches/SpaceDustForBlueshift.cfg
@@ -477,7 +477,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		HARVESTED_RESOURCE
 		{
 			Name = Graviolium
-			MinHarvestValue = 0.00000000000000000001
+			MinHarvestValue = 0.00000000000000000000000000000000000000000000000000001
 			BaseEfficiency = 1
 		}
 	}
@@ -533,7 +533,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		{
 			Name = Graviolium
 			BaseEfficiency = .2
-			MinHarvestValue = 0.0000000001
+			MinHarvestValue = 0.0000000000000000000000000000000000000000000001
 		}
 		HARVESTED_RESOURCE:NEEDS[WildBlueIndustries/ClassicStock]
 		{
@@ -652,7 +652,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		{
 			Name = Graviolium
 			BaseEfficiency = .1
-			MinHarvestValue = 0.0000000001
+			MinHarvestValue = 0.00000000000000000000000000000000000000001
 		}
 		HARVESTED_RESOURCE:NEEDS[WildBlueIndustries/ClassicStock]
 		{
@@ -771,7 +771,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		{
 			Name = Graviolium
 			BaseEfficiency = .2
-			MinHarvestValue = 0.0000000001
+			MinHarvestValue = 0.0000000000000000000000000000000000000000000000000000000001
 		}
 		HARVESTED_RESOURCE:NEEDS[WildBlueIndustries/ClassicStock]
 		{

--- a/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/SpaceDustForBlueshift.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Blueshift/Patches/SpaceDustForBlueshift.cfg
@@ -477,7 +477,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		HARVESTED_RESOURCE
 		{
 			Name = Graviolium
-			MinHarvestValue = 0.00000000000000000001
+			MinHarvestValue = 0.00000000000000000000000000000000000000000000000000001
 			BaseEfficiency = 1
 		}
 	}
@@ -533,7 +533,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		{
 			Name = Graviolium
 			BaseEfficiency = .2
-			MinHarvestValue = 0.0000000001
+			MinHarvestValue = 0.0000000000000000000000000000000000000000000001
 		}
 		HARVESTED_RESOURCE:NEEDS[WildBlueIndustries/ClassicStock]
 		{
@@ -652,7 +652,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		{
 			Name = Graviolium
 			BaseEfficiency = .1
-			MinHarvestValue = 0.0000000001
+			MinHarvestValue = 0.00000000000000000000000000000000000000001
 		}
 		HARVESTED_RESOURCE:NEEDS[WildBlueIndustries/ClassicStock]
 		{
@@ -771,7 +771,7 @@ SPACEDUST_INSTRUMENT:NEEDS[!WildBlueIndustries/FlyingSaucers,SpaceDust]
 		{
 			Name = Graviolium
 			BaseEfficiency = .2
-			MinHarvestValue = 0.0000000001
+			MinHarvestValue = 0.0000000000000000000000000000000000000000000000000000000001
 		}
 		HARVESTED_RESOURCE:NEEDS[WildBlueIndustries/ClassicStock]
 		{


### PR DESCRIPTION
This patch simply sets the minHarvestValue of all graviolium SpaceDust harvesters extremely low. Without this patch, the minHarvestValue of the harvesters was higher than the maxAbundance of most graviolium resource bands, effectively making the entire spacedust portion of the mod useless. With this patch, the space dust harvesters will always work when in a resource band, and will still fail if not in a resource band.

Also, may I use my fork of blueshift until this pull request is approved?